### PR TITLE
get ignore urls from wp-config.php, if not found set a default of the base-url and wordpress.org

### DIFF
--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -213,15 +213,27 @@ class Inspect_Http_Requests_Admin {
 	 * @since    1.0.0
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
-		/* Get URL of the wordpress site */
-		$site_url = home_url();
-  
-		/* Create Whitelist */
-		$whitelisted_urls = "$site_url wordpress.org";
 
-                if ( false !== strpos( $whitelisted_urls, $data['URL'] ) ) {
-                        return false;
-                }
+		/* Try to get $ignored_urls from wp.config.php */
+		$ignored_urls = get_option('inspect-http-requests-ignored-urls');
+
+		/* Not found? Create a default */
+		if ( !is_array( $ignored_urls ) ) {
+			/* Get the BASE-URL of the wordpress site and remove the scheme  */
+			$site_url = home_url();
+			$url_parts = parse_url($site_url);
+	       		$url_base  = $url_parts['host'];
+			/* Create $ignored_urls */
+			$ignored_urls = [ $url_base, 'wordpress.org'];
+		}
+
+		/* Loop through the ignorelist */
+		foreach ($ignored_urls as $iu) {
+                	if ( false !== strpos( $data['URL'], $iu ) ) {
+                        	return false;
+                	}
+		}
+
 		if ( ets_inspect_http_request_check_duplicate_url( $data['URL'] ) ) {
 			return false;
 		}

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -213,11 +213,9 @@ class Inspect_Http_Requests_Admin {
 	 * @since    1.0.0
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
-
 		/* Get URL of the wordpress site */
 		$site_url = home_url();
-                preg_replace('/https?\/\//', '', $site_url);
-
+  
 		/* Create Whitelist */
 		$whitelisted_urls = "$site_url wordpress.org";
 

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -213,9 +213,17 @@ class Inspect_Http_Requests_Admin {
 	 * @since    1.0.0
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
-		if ( false !== strpos( $data['URL'], 'wordpress.org' ) ) {
-			return false;
-		}
+
+		/* Get URL of the wordpress site */
+		$site_url = home_url();
+                preg_replace('/https?\/\//', '', $site_url);
+
+		/* Create Whitelist */
+		$whitelisted_urls = "$site_url wordpress.org";
+
+                if ( false !== strpos( $whitelisted_urls, $data['URL'] ) ) {
+                        return false;
+                }
 		if ( ets_inspect_http_request_check_duplicate_url( $data['URL'] ) ) {
 			return false;
 		}


### PR DESCRIPTION
Ignore requests directed at our own site, this is needed for crawlers and preloaders without cluttering the database.