### PR TITLE
Create a list of ignored hosts (or parts of it) in wp.config

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: expresstechsoftware, webbdeveloper, sunnysoni, vanbom
+Contributors: expresstechsoftware, webbdeveloper, sunnysoni, vanbom, eilandert
 Donate link: https://paypal.me/supportets
 Tags: log, wp_http, requests, update checks, api, http_api_debug, pre_http_request, http_request_args
 Requires at least: 3.0.1
@@ -18,16 +18,27 @@ Track how much time a request like updating core/plugin/theme taking (may be use
 
 This plugin logs all WP_HTTP requests and displays them in a table listing for easy viewing. It also stores the runtime of each HTTP request.
 
-= Available Hooks =
-Don't log items from a specific hostname:
+If you add a base-url manually, e.g. https://api.woocommerce.com,  there will be no more entries stored for that host.
 
+= Available Hooks =
+
+Add the following to wp-config.php for default blocking:
 <pre>
-add_filter( 'ets_inspect_http_requests_ignore_hostname', function( $data ) {
-    if ( false !== strpos( $data['url'], 'wordpress.org' ) ) {
-        return false;
-    }
-    return $data;
-});
+define( 'inspect-http-requests-default-block', true );
+</pre>
+
+To prevent database littering and sql lookups you can ignore (parts of) hostnames: 
+(without this, your own site and wordpress.org are ignored)
+<pre>
+define( 'inspect-http-requests-ignored-urls', [
+        'your own site',
+        'wordpress.org',
+        'api.woocommerce.com',
+        'wp-rocket.me',
+        'ip-api.com',
+        'ipinfo.io',
+	'api',
+]);
 </pre>
 
 = Important Links =

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -221,7 +221,7 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                $ignored_urls = get_option(inspect_http_requests_ignored_urls);
+                $ignored_urls = get_option('inspect_http_requests_ignored_urls');
                 if ( !is_array( $ignored_urls ) ) {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
                         $site_url = home_url();

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -221,7 +221,8 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                $ignored_urls = get_option('inspect_http_requests_ignored_urls');
+
+                $ignored_urls = inspect_http_requests_ignored_urls;
                 if ( !is_array( $ignored_urls ) ) {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
                         $site_url = home_url();

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -149,10 +149,11 @@ class Inspect_Http_Requests_Admin {
 		$table_name = $this->table_name;
 
 	        /* Try to get $defaultblock from wp_config.php */
-                $defaultblock = get_option('inspect-http-requests-default-block');
-                if ($defaultblock == true) {
-                        $defaultblock = 1;
-                } else { $defaultblock = 0; }
+		if (isset $inspect_http_requests_default_block) {
+	                $defaultblock = $inspect_http_requests_default_block;
+		} else {
+			$defaultblock = 0;
+		}
 
 		$request_args       = json_encode( $args );
 		$http_api_call_data = apply_filters(
@@ -287,10 +288,11 @@ class Inspect_Http_Requests_Admin {
 		}
 
 		/* Try to get $defaultblock from wp_config.php */
-                $defaultblock = get_option('inspect-http-requests-default-block');
-                if ($defaultblock == true) {
-                        $defaultblock = 1;
-                } else { $defaultblock = 0; }
+                if (isset $inspect_http_requests_default_block) {
+                        $defaultblock = $inspect_http_requests_default_block;
+                } else {
+                        $defaultblock = 0;
+                }
 
 		$http_api_call_data = apply_filters( 'ets_inspect_http_requests_ignore_hostname', array(
 			'URL' => sanitize_url ( $_POST['valid_url'] ),

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -213,13 +213,12 @@ class Inspect_Http_Requests_Admin {
 	 * @since    1.0.0
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
-
-		/* Try to get $ignored_urls from wp.config.php */
-		$ignored_urls = get_option('inspect-http-requests-ignored-urls');
-
-		/* Not found? Create a default */
-		if ( !is_array( $ignored_urls ) ) {
-			/* Get the BASE-URL of the wordpress site and remove the scheme  */
+                /* Try to get array $ignored_urls from wp.config.php */
+                if (is_array( $inspect-http-requests-ignored-urls ) ) {
+                        $ignored_urls = $inspect-http-requests-ignored-urls;
+                } else {
+			/* Not found? Create a default */
+                        /* Get the BASE-URL of our wordpress site and remove the scheme */
 			$site_url = home_url();
 			$url_parts = parse_url($site_url);
 	       		$url_base  = $url_parts['host'];

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -213,9 +213,27 @@ class Inspect_Http_Requests_Admin {
 	 * @since    1.0.0
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
-		if ( false !== strpos( $data['URL'], 'wordpress.org' ) ) {
-			return false;
+
+		/* Try to get $ignored_urls from wp.config.php */
+		$ignored_urls = get_option('inspect-http-requests-ignored-urls');
+
+		/* Not found? Create a default */
+		if ( !is_array( $ignored_urls ) ) {
+			/* Get the BASE-URL of the wordpress site and remove the scheme  */
+			$site_url = home_url();
+			$url_parts = parse_url($site_url);
+	       		$url_base  = $url_parts['host'];
+			/* Create $ignored_urls */
+			$ignored_urls = [ $url_base, 'wordpress.org'];
 		}
+
+		/* Loop through the ignorelist */
+		foreach ($ignored_urls as $iu) {
+                	if ( false !== strpos( $data['URL'], $iu ) ) {
+                        	return false;
+                	}
+		}
+
 		if ( ets_inspect_http_request_check_duplicate_url( $data['URL'] ) ) {
 			return false;
 		}

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -214,17 +214,15 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                if (is_array( $inspect_http_requests_ignored_urls ) ) {
-                        $ignored_urls = $inspect_http_requests_ignored_urls;
-                } else {
-			/* Not found? Create a default */
+                $ignored_urls = get_config(inspect_http_requests_ignored_urls);
+                if ( !is_array( $ignored_urls ) ) {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
-			$site_url = home_url();
-			$url_parts = parse_url($site_url);
-	       		$url_base  = $url_parts['host'];
-			/* Create $ignored_urls */
-			$ignored_urls = [ $url_base, 'wordpress.org'];
-		}
+                        $site_url = home_url();
+                        $url_parts = parse_url($site_url);
+                        $url_base  = $url_parts['host'];
+                        /* Create $ignored_urls */
+                        $ignored_urls = [ $url_base, 'wordpress.org'];
+                }
 
 		/* Loop through the ignorelist */
 		foreach ($ignored_urls as $iu) {

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -214,7 +214,7 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                $ignored_urls = get_config(inspect_http_requests_ignored_urls);
+                $ignored_urls = get_option(inspect_http_requests_ignored_urls);
                 if ( !is_array( $ignored_urls ) ) {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
                         $site_url = home_url();

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -221,9 +221,9 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-
-                $ignored_urls = inspect_http_requests_ignored_urls;
-                if ( !is_array( $ignored_urls ) ) {
+                if ( defined( 'inspect_http_requests_ignored_urls' ) ) {
+                       $ignored_urls = inspect_http_requests_ignored_urls;
+                } else {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
                         $site_url = home_url();
                         $url_parts = parse_url($site_url);

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -288,7 +288,7 @@ class Inspect_Http_Requests_Admin {
 		}
 
 		/* Try to get $defaultblock from wp_config.php */
-                if ( isset $inspect_http_requests_default_block ) ) {
+                if ( isset( $inspect_http_requests_default_block ) ) {
                         $defaultblock = $inspect_http_requests_default_block;
                 } else {
                         $defaultblock = 0;

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -214,7 +214,7 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                $ignored_urls = get_option('inspect_http_requests_ignored_urls');
+                $ignored_urls = inspect_http_requests_ignored_urls;
                 if ( !is_array( $ignored_urls ) ) {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
                         $site_url = home_url();

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -214,7 +214,7 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                $ignored_urls = get_option(inspect_http_requests_ignored_urls);
+                $ignored_urls = get_option('inspect_http_requests_ignored_urls');
                 if ( !is_array( $ignored_urls ) ) {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
                         $site_url = home_url();

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -149,7 +149,7 @@ class Inspect_Http_Requests_Admin {
 		$table_name = $this->table_name;
 
 	        /* Try to get $defaultblock from wp_config.php */
-		if (isset $inspect_http_requests_default_block) {
+		if ( isset( $inspect_http_requests_default_block ) ) {
 	                $defaultblock = $inspect_http_requests_default_block;
 		} else {
 			$defaultblock = 0;
@@ -288,7 +288,7 @@ class Inspect_Http_Requests_Admin {
 		}
 
 		/* Try to get $defaultblock from wp_config.php */
-                if (isset $inspect_http_requests_default_block) {
+                if ( isset $inspect_http_requests_default_block ) ) {
                         $defaultblock = $inspect_http_requests_default_block;
                 } else {
                         $defaultblock = 0;

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -221,7 +221,7 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                $ignored_urls = get_config(inspect_http_requests_ignored_urls);
+                $ignored_urls = get_option(inspect_http_requests_ignored_urls);
                 if ( !is_array( $ignored_urls ) ) {
                         /* Get the BASE-URL of our wordpress site and remove the scheme */
                         $site_url = home_url();

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -148,6 +148,12 @@ class Inspect_Http_Requests_Admin {
 		}
 		$table_name = $this->table_name;
 
+	        /* Try to get $defaultblock from wp_config.php */
+                $defaultblock = get_option('inspect-http-requests-default-block');
+                if ($defaultblock == true) {
+                        $defaultblock = 1;
+                } else { $defaultblock = 0; }
+
 		$request_args       = json_encode( $args );
 		$http_api_call_data = apply_filters(
 			'ets_inspect_http_requests_ignore_hostname',
@@ -158,7 +164,7 @@ class Inspect_Http_Requests_Admin {
 				'transport'    => $transport,
 				'runtime'      => ( microtime( true ) - $this->start_time ),
 				'date_added'   => date( 'Y-m-d H:i:s' ),
-				'is_blocked'   => 0,
+				'is_blocked'   => $defaultblock,
 			)
 		);
 		if ( false !== $http_api_call_data ) {
@@ -280,6 +286,12 @@ class Inspect_Http_Requests_Admin {
 			exit();
 		}
 
+		/* Try to get $defaultblock from wp_config.php */
+                $defaultblock = get_option('inspect-http-requests-default-block');
+                if ($defaultblock == true) {
+                        $defaultblock = 1;
+                } else { $defaultblock = 0; }
+
 		$http_api_call_data = apply_filters( 'ets_inspect_http_requests_ignore_hostname', array(
 			'URL' => sanitize_url ( $_POST['valid_url'] ),
 			'request_args' => '',
@@ -287,7 +299,7 @@ class Inspect_Http_Requests_Admin {
 			'transport' => '', 
 			'runtime' => '',
 			'date_added' => date('Y-m-d H:i:s'),
-			'is_blocked' => 0                    
+			'is_blocked' => $defaultblock, 
 			) ) ;
 		if ( false !== $http_api_call_data ) {
 			if ( ! $wpdb->insert( $table_name, $http_api_call_data ) ) {

--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -214,8 +214,8 @@ class Inspect_Http_Requests_Admin {
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
                 /* Try to get array $ignored_urls from wp.config.php */
-                if (is_array( $inspect-http-requests-ignored-urls ) ) {
-                        $ignored_urls = $inspect-http-requests-ignored-urls;
+                if (is_array( $inspect_http_requests_ignored_urls ) ) {
+                        $ignored_urls = $inspect_http_requests_ignored_urls;
                 } else {
 			/* Not found? Create a default */
                         /* Get the BASE-URL of our wordpress site and remove the scheme */

--- a/includes/class-inspect-http-requests-admin-notices.php
+++ b/includes/class-inspect-http-requests-admin-notices.php
@@ -18,7 +18,7 @@ class Inspect_Http_Requests_Admin_Notices {
 	 */
 	public static function init() {
 
-		add_action( 'admin_notices', array( __CLASS__, 'ets_inspect_http_requests_display_notification' ) );
+		// add_action( 'admin_notices', array( __CLASS__, 'ets_inspect_http_requests_display_notification' ) );
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7,7 +7,7 @@ function ets_inspect_http_request_get_data( $search = false ) {
 	global $wpdb;
 	$table_name = $wpdb->prefix . 'ets_wp_outbound_http_requests';
 	if ( $search === false ) {
-		$sql = "SELECT * FROM {$table_name} ORDER BY `is_blocked` DESC, `URL` ASC, `ID` ASC ;";
+		$sql = "SELECT * FROM {$table_name} ORDER BY `ID` ASC ;";
 	} else {
 		$sql = "SELECT * FROM {$table_name} WHERE `URL` LIKE '%$search%' OR `request_args` LIKE '%$search%' OR `response` LIKE '%$search%'  ORDER BY `ID` ASC ;";
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -35,16 +35,30 @@ function ets_inspect_http_request_check_duplicate_url( $url ) {
 	global $wpdb;
 	$table_name = $wpdb->prefix . 'ets_wp_outbound_http_requests';
 
-	$sql_query = "SELECT count(`ID`) AS c FROM `{$table_name}` WHERE LOWER(`URL`) = '" . strtolower( trim( $url ) ) . "' ;";
+        /*
+        * Get the base url. Compare it in the database.
+        * If it's manually added it has runtime 0 and we want to ignore it.
+        * This works currently only with base urls
+        */
 
-	$result = $wpdb->get_results( $sql_query, ARRAY_A );
+        $url_parts = parse_url($url);
+        $url_base  = $url_parts['scheme'] . '://' . $url_parts['host'];
+        $sql_query = "SELECT count(`runtime`) AS c FROM `{$table_name}` WHERE LOWER(`URL`) = '" . strtolower( trim( $url_base ) ) . "' and runtime = '' ;";
+        $result = $wpdb->get_results( $sql_query, ARRAY_A );
 
-	if ( is_array( $result ) && isset( $result[0]['c'] ) && $result[0]['c'] >= 1 ) {
-		return true;
-	} else {
-		return false;
-	}
+        if ( is_array( $result ) && isset( $result[0]['c'] ) && $result[0]['c'] >= 1 ) {
+                return true;
+        }
 
+        $sql_query = "SELECT count(`ID`) AS c FROM `{$table_name}` WHERE LOWER(`URL`) = '" . strtolower( trim( $url ) ) . "' ;";
+
+        $result = $wpdb->get_results( $sql_query, ARRAY_A );
+
+        if ( is_array( $result ) && isset( $result[0]['c'] ) && $result[0]['c'] >= 1 ) {
+                return true;
+        }
+
+        return false;
 }
 
 function ets_inspect_http_request_log_blocked_url( $url ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7,7 +7,7 @@ function ets_inspect_http_request_get_data( $search = false ) {
 	global $wpdb;
 	$table_name = $wpdb->prefix . 'ets_wp_outbound_http_requests';
 	if ( $search === false ) {
-		$sql = "SELECT * FROM {$table_name} ORDER BY `ID` ASC ;";
+		$sql = "SELECT * FROM {$table_name} ORDER BY `is_blocked` DESC, `URL` ASC, `ID` ASC ;";
 	} else {
 		$sql = "SELECT * FROM {$table_name} WHERE `URL` LIKE '%$search%' OR `request_args` LIKE '%$search%' OR `response` LIKE '%$search%'  ORDER BY `ID` ASC ;";
 	}


### PR DESCRIPTION
Get a list from wp-config.php or set a default of our own site + wordpress.org.
This prevents performance issues and database cluttering on busy api's and caching plugins which preload url's

Enable by putting the following in wp-config.php
define( 'inspect-http-requests-ignored-urls', ['yoursite.com','api.wordpress.org','api'] );